### PR TITLE
feat: add external wallet balance option

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -9,10 +9,11 @@ import chalk from "chalk";
 import { deployCommand } from "../src/commands/deploy.js";
 import { verifyCommand } from "../src/commands/verify.js";
 import { ReadContract } from "../src/commands/contract.js";
+import { Address } from "viem";
 
 interface CommandOptions {
   testnet?: boolean;
-  address?: string;
+  address?: Address;
   value?: string;
   txid?: string;
   abi?: string;
@@ -55,8 +56,9 @@ program
   .command("balance")
   .description("Check the balance of the saved wallet")
   .option("-t, --testnet", "Check the balance on the testnet")
+  .option("-a, --address <address>", "Check the balance of a specific address")
   .action(async (options: CommandOptions) => {
-    await balanceCommand(!!options.testnet);
+    await balanceCommand(!!options.testnet, options.address);
   });
 
 program

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "tsc",
     "wallet": "pnpm run build && node dist/bin/index.js wallet",
     "balance": "pnpm run build && node dist/bin/index.js balance",
+    "balance-of": "pnpm run build && node dist/bin/index.js balance -t --address 0x02C8345B2DF9Ff6122b0bE7B79cB219d956bd701",
     "transfer": "pnpm run build && node dist/bin/index.js transfer --testnet --address 0xa5f45f5bddefC810C48aCC1D5CdA5e5a4c6BC59E --value 0.001",
     "tx-status": "pnpm run build && node dist/bin/index.js tx --testnet --txid 0x876a0a9b167889350c41930a4204e5d9acf5704a7f201447a337094189af961c4"
   },


### PR DESCRIPTION
Implemented a feature to easily check balances for any address on Rootstock 


added   `-a` | `-address` tag in balace

![image](https://github.com/user-attachments/assets/11b28421-5c51-4415-846f-e75fde243e3d)
![image](https://github.com/user-attachments/assets/c0ed404a-4a06-4cad-ae5d-538b1f32bf42)
