### PR TITLE
fix: correct spelling of "Rootstack" to "Rootstock" in README and his…

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ Output example:
 
 ```
 ? 🔒 Enter Alchemy API key to fetch history: ********************************
-🔍 Fetching transaction history on Rootstack Testnet for 0x19661D036D4e590948b9c00eef3807b88fBfA8e1 ...
+🔍 Fetching transaction history on Rootstock Testnet for 0x19661D036D4e590948b9c00eef3807b88fBfA8e1 ...
 ✅ Transfer:
    From: 0x19661d036d4e590948b9c00eef3807b88fbfa8e1
    To: 0xb45805aead9407f5c7860ff8eccaedd4d0ab36a6

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -50,7 +50,7 @@ export async function historyCommand(
 
     console.log(
       chalk.blue(
-        `🔍 Fetching transaction history on Rootstack ${
+        `🔍 Fetching transaction history on Rootstock ${
           testnet ? "Testnet" : "Mainnet"
         } for ${walletAddress} ... `
       )


### PR DESCRIPTION


### Summary

- Corrected the example output in the README to show “Rootstock Testnet”

Output example:
```diff
- 🔍 Fetching transaction history on Rootstack Testnet for 0x19661D036D4e590948b9c00eef3807b88fBfA8e1 ...
+ 🔍 Fetching transaction history on Rootstock Testnet for 0x19661D036D4e590948b9c00eef3807b88fBfA8e1 ...
```


- Corrected the history command message to reference “Rootstock” correctly:

```diff
- 🔍 Fetching transaction history on Rootstack ${
-   testnet ? "Testnet" : "Mainnet"
- } for ${walletAddress} ...
+ 🔍 Fetching transaction history on Rootstock ${
+   testnet ? "Testnet" : "Mainnet"
+ } for ${walletAddress} ...
