### PR TITLE
feat: add address validation and formatting in address book command

### DIFF
--- a/src/commands/addressbook.ts
+++ b/src/commands/addressbook.ts
@@ -1,6 +1,6 @@
 import inquirer from "inquirer";
 import chalk from "chalk";
-import { loadWallets } from "../utils/index.js";
+import { loadWallets, validateAndFormatAddress } from "../utils/index.js";
 import { walletFilePath } from "../utils/constants.js";
 import { writeWalletData } from "./wallet.js";
 
@@ -45,7 +45,12 @@ export async function addressBookCommand() {
         return;
       }
 
-      walletsData.addressBook[label] = address;
+      const formattedAddress = validateAndFormatAddress(address);
+      if (!formattedAddress) {
+        return;
+      }
+
+      walletsData.addressBook[label] = formattedAddress;
       console.log(chalk.green(`✅ Address added under label "${label}".`));
     }
 
@@ -86,7 +91,12 @@ export async function addressBookCommand() {
         },
       ]);
 
-      walletsData.addressBook[label] = newAddress;
+      const formattedAddress = validateAndFormatAddress(newAddress);
+      if (!formattedAddress) {
+        return;
+      }
+
+      walletsData.addressBook[label] = formattedAddress;
       console.log(chalk.green(`✅ Address for "${label}" updated.`));
     }
 


### PR DESCRIPTION
### Summary

- **Main Change:**  
  Added address validation and formatting to the address book command.

**Explanation of Changes:**
- Imported a new helper function, `validateAndFormatAddress`, from `../utils/index.js`.
- When adding or updating an address in the address book, the code now:
  - Calls `validateAndFormatAddress` on the input address.
  - If the address is invalid (the function returns a falsy value), the command exits early without saving the address.
  - Only a valid, formatted address is saved to the address book under the given label.
- This validation logic was added both when adding a new address and updating an existing one.

**Impact:**  
This change improves the reliability of the address book by ensuring that only properly validated and formatted addresses are stored, reducing potential errors from invalid addresses.

Changes:
![image](https://github.com/user-attachments/assets/3e47646b-7760-4e45-97e9-1670d002cee2)

![image](https://github.com/user-attachments/assets/73dde30a-b7f6-4a8d-bd7f-1b7614ec7844)


![image](https://github.com/user-attachments/assets/2dafd520-accd-49c1-94a8-48dca1abd1a6)
