### PR TITLE
feat(contract): add write function support via --write flag

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -322,11 +322,13 @@ program
   .requiredOption("-a, --address <address>", "Address of a verified contract")
   .option("-t, --testnet", "Deploy on the testnet")
   .option("--write", "Call write (nonpayable/payable) functions")
+  .option("--wallet <wallet>", "Name of the wallet")
   .action(async (options: CommandOptions) => {
     await ReadContract({
       address: options.address! as `0x${string}`,
       testnet: !!options.testnet,
       write: !!options.write,
+      wallet: options.wallet,
     });
   });
 

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -80,6 +80,7 @@ interface CommandOptions {
   attestRecipient?: string;
   attestReason?: string;
   rns?: string;
+  write?: boolean;
 }
 
 const orange = chalk.rgb(255, 165, 0);
@@ -319,10 +320,12 @@ program
   .description("Interact with a contract")
   .requiredOption("-a, --address <address>", "Address of a verified contract")
   .option("-t, --testnet", "Deploy on the testnet")
+  .option("--write", "Call write (nonpayable/payable) functions")
   .action(async (options: CommandOptions) => {
     await ReadContract({
       address: options.address! as `0x${string}`,
       testnet: !!options.testnet,
+      write: !!options.write,
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "batch-transfer": "pnpm run build && node dist/bin/index.js batch-transfer",
     "history": "pnpm run build && node dist/bin/index.js history",
     "config": "pnpm run build && node dist/bin/index.js config",
-    "contract:write": "node dist/bin/index.js contract --testnet -a 0xcb46c0ddc60d18efeb0e586c17af6ea36452dae0 --write"
+    "contract:write": "pnpm run build && node dist/bin/index.js contract --testnet --write -a <contract-address>"
   },
   "keywords": [
     "rootstock",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "tx-status": "pnpm run build && node dist/bin/index.js tx --testnet --txid 0x876a0a9b167889350c41930a4204e5d9acf5704a7f201447a337094189af961c4",
     "batch-transfer": "pnpm run build && node dist/bin/index.js batch-transfer",
     "history": "pnpm run build && node dist/bin/index.js history",
-    "config": "pnpm run build && node dist/bin/index.js config"
+    "config": "pnpm run build && node dist/bin/index.js config",
+    "contract:write": "node dist/bin/index.js contract --testnet -a 0xcb46c0ddc60d18efeb0e586c17af6ea36452dae0 --write"
   },
   "keywords": [
     "rootstock",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "batch-transfer": "pnpm run build && node dist/bin/index.js batch-transfer",
     "history": "pnpm run build && node dist/bin/index.js history",
     "config": "pnpm run build && node dist/bin/index.js config",
+    "contract:read": "pnpm run build && node dist/bin/index.js contract --testnet -a <contract-address>",
     "contract:write": "pnpm run build && node dist/bin/index.js contract --testnet --write -a <contract-address>"
   },
   "keywords": [

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -6,11 +6,6 @@ import { getExplorerUrl } from "../utils/constants.js";
 import { logError, logSuccess, logInfo, logWarning } from "../utils/logger.js";
 import { createSpinner } from "../utils/spinner.js";
 
-type InquirerAnswers = {
-  selectedFunction?: string;
-  args?: string[];
-};
-
 type ContractCommandOptions = {
   address: `0x${string}`;
   testnet: boolean;
@@ -34,8 +29,25 @@ function coerceArg(value: string, solidityType: string): any {
       throw new Error(`Expected JSON for type ${solidityType}, got: ${value}`);
     }
   }
-  if (/^u?int(\d+)?$/.test(solidityType)) {
-    return BigInt(value);
+  const intMatch = solidityType.match(/^(u?)int(\d+)?$/);
+  if (intMatch) {
+    const isUnsigned = intMatch[1] === "u";
+    const bits = intMatch[2] ? parseInt(intMatch[2], 10) : 256;
+    let parsed: bigint;
+    try {
+      parsed = BigInt(value);
+    } catch {
+      throw new Error(`Invalid integer value for type ${solidityType}: ${value}`);
+    }
+    if (isUnsigned) {
+      if (parsed < 0n) throw new Error(`Type ${solidityType} cannot be negative`);
+      if (parsed >= 2n ** BigInt(bits)) throw new Error(`Value ${value} exceeds maximum for ${solidityType}`);
+    } else {
+      const min = -(2n ** BigInt(bits - 1));
+      const max = 2n ** BigInt(bits - 1) - 1n;
+      if (parsed < min || parsed > max) throw new Error(`Value ${value} is out of range for ${solidityType}`);
+    }
+    return parsed;
   }
   if (solidityType === "address") {
     if (!isValidAddress(value)) throw new Error(`Invalid address: ${value}`);
@@ -75,6 +87,9 @@ function validateAbi(abi: any): boolean {
       if (typeof item.name !== "string") return false;
       if (!Array.isArray(item.inputs)) return false;
       if (typeof item.stateMutability !== "string") return false;
+      for (const input of item.inputs) {
+        if (typeof input.type !== "string") return false;
+      }
     }
   }
   return true;
@@ -226,7 +241,11 @@ export async function contractCommand(
       const provider = new ViemProvider(params.testnet);
       const publicClient = await provider.getPublicClient();
       const { client: walletClient } = await provider.getWalletClientWithPassword(params.wallet);
-      const account = walletClient.account!;
+      if (!walletClient.account) {
+        logError(isExternal, "Wallet account not available.");
+        return { error: "Wallet account not available.", success: false };
+      }
+      const account = walletClient.account;
 
       if (payableValue !== undefined) {
         const balance = await publicClient.getBalance({ address: account.address });
@@ -294,8 +313,11 @@ export async function contractCommand(
         txHash = await walletClient.writeContract(simulateRequest);
       } catch (err: any) {
         spinner.fail("❌ Submission failed.");
-        logError(isExternal, err.shortMessage || err.message || "Failed to submit transaction.");
-        return { error: err.shortMessage || err.message || "Submission failed.", success: false };
+        const submitMsg = isExternal
+          ? "Transaction submission failed."
+          : err.shortMessage || err.message || "Failed to submit transaction.";
+        logError(isExternal, submitMsg);
+        return { error: submitMsg, success: false };
       }
 
       spinner.stop();
@@ -378,23 +400,30 @@ export async function contractCommand(
         };
       }
     } else {
-      const questions: any = [
+      const readFnSignature = (item: any) => {
+        const paramTypes = (item.inputs ?? []).map((i: any) => i.type).join(",");
+        return `${item.name}(${paramTypes})`;
+      };
+
+      const { selectedReadSig } = await inquirer.prompt<{ selectedReadSig: string }>([
         {
           type: "list",
-          name: "selectedFunction",
+          name: "selectedReadSig",
           message: "Select a read function to call:",
-          choices: [...readFunctions.map((item: any) => item.name)],
+          choices: readFunctions.map(readFnSignature),
         },
-      ];
-
-      const answers = await inquirer.prompt<InquirerAnswers>(questions);
-      selectedFunction = answers.selectedFunction!;
-
-      logSuccess(isExternal, `📜 You selected: ${selectedFunction}`);
+      ]);
 
       selectedAbiFunction = readFunctions.find(
-        (item: any) => item.name === selectedFunction
+        (item: any) => readFnSignature(item) === selectedReadSig
       );
+
+      if (!selectedAbiFunction) {
+        return { error: "Selected function not found in ABI.", success: false };
+      }
+
+      selectedFunction = selectedAbiFunction.name;
+      logSuccess(isExternal, `📜 You selected: ${selectedReadSig}`);
     }
 
     let args: any[] = [];
@@ -411,15 +440,15 @@ export async function contractCommand(
         }
         args = params.args;
       } else {
-        const argQuestions = selectedAbiFunction.inputs.map((input: any) => ({
+        const argQuestions = selectedAbiFunction.inputs.map((input: any, idx: number) => ({
           type: "input",
-          name: input.name,
-          message: `Enter the value for argument ${input.name} (${input.type}):`,
+          name: `arg_${idx}`,
+          message: `Enter the value for argument ${input.name || `arg${idx}`} (${input.type}):`,
         }));
 
         const answers = await inquirer.prompt(argQuestions);
         args = selectedAbiFunction.inputs.map(
-          (input: any) => answers[input.name]
+          (_input: any, idx: number) => answers[`arg_${idx}`]
         );
       }
     }

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -15,11 +15,11 @@ type ContractCommandOptions = {
   address: `0x${string}`;
   testnet: boolean;
   write?: boolean;
+  wallet?: string;
   isExternal?: boolean;
   functionName?: string;
   args?: string[];
 };
-
 
 function isValidAddress(address: string): boolean {
   const regex = /^0x[a-fA-F0-9]{40}$/;
@@ -46,15 +46,41 @@ function coerceArg(value: string, solidityType: string): any {
     if (value === "false") return false;
     throw new Error(`Invalid bool: "${value}". Use "true" or "false".`);
   }
-  if (/^bytes(\d+)?$/.test(solidityType)) {
+  const bytesMatch = solidityType.match(/^bytes(\d+)?$/);
+  if (bytesMatch) {
     if (!/^0x[a-fA-F0-9]*$/.test(value))
       throw new Error(`Invalid hex for type ${solidityType}: ${value}`);
+    const n = bytesMatch[1] ? parseInt(bytesMatch[1], 10) : null;
+    if (n !== null) {
+      const expectedLen = 2 + n * 2;
+      if (value.length !== expectedLen)
+        throw new Error(
+          `Type ${solidityType} requires exactly ${n} bytes (${expectedLen} hex chars including 0x), got ${value.length}`
+        );
+    }
+    return value;
+  }
+  if (/^u?fixed(\d+x\d+)?$/.test(solidityType)) {
     return value;
   }
   return value;
 }
 
-export async function ReadContract(
+function validateAbi(abi: any): boolean {
+  if (!Array.isArray(abi)) return false;
+  for (const item of abi) {
+    if (typeof item !== "object" || item === null) return false;
+    if (typeof item.type !== "string") return false;
+    if (item.type === "function") {
+      if (typeof item.name !== "string") return false;
+      if (!Array.isArray(item.inputs)) return false;
+      if (typeof item.stateMutability !== "string") return false;
+    }
+  }
+  return true;
+}
+
+export async function contractCommand(
   params: ContractCommandOptions
 ): Promise<ContractResult | void> {
   const isExternal = params.isExternal || false;
@@ -64,10 +90,7 @@ export async function ReadContract(
     const errorMessage =
       "Invalid address format. Please provide a valid address.";
     logError(isExternal, `❌ ${errorMessage}`);
-    return {
-      error: errorMessage,
-      success: false,
-    };
+    return { error: errorMessage, success: false };
   }
 
   logInfo(
@@ -94,10 +117,7 @@ export async function ReadContract(
     if (!response.ok) {
       const errorMessage = "Error during verification check.";
       spinner.fail(errorMessage);
-      return {
-        error: errorMessage,
-        success: false,
-      };
+      return { error: errorMessage, success: false };
     }
 
     const resData = await response.json();
@@ -105,13 +125,16 @@ export async function ReadContract(
     if (!resData.data) {
       const errorMessage = "Contract verification not found.";
       spinner.fail(errorMessage);
-      return {
-        error: errorMessage,
-        success: false,
-      };
+      return { error: errorMessage, success: false };
     }
 
     const { abi } = resData.data;
+
+    if (!validateAbi(abi)) {
+      const errorMessage = "Contract ABI from API is malformed or invalid.";
+      spinner.fail(errorMessage);
+      return { error: errorMessage, success: false };
+    }
 
     if (params.write) {
       spinner.stop();
@@ -128,33 +151,44 @@ export async function ReadContract(
         return { error: "No write functions found in this contract.", success: false };
       }
 
-      const { selectedWriteFn } = await inquirer.prompt<{ selectedWriteFn: string }>([
+      const fnSignature = (item: any) => {
+        const paramTypes = (item.inputs ?? []).map((i: any) => i.type).join(",");
+        return `${item.name}(${paramTypes})`;
+      };
+
+      const { selectedSig } = await inquirer.prompt<{ selectedSig: string }>([
         {
           type: "list",
-          name: "selectedWriteFn",
+          name: "selectedSig",
           message: "Select a write function to call:",
-          choices: writeFunctions.map((item: any) => item.name),
+          choices: writeFunctions.map(fnSignature),
         },
       ]);
 
-      logSuccess(isExternal, `📜 You selected: ${selectedWriteFn}`);
-
       const selectedAbiWriteFn = writeFunctions.find(
-        (item: any) => item.name === selectedWriteFn
+        (item: any) => fnSignature(item) === selectedSig
       );
+
+      if (!selectedAbiWriteFn) {
+        logError(isExternal, "Selected function not found in ABI.");
+        return { error: "Selected function not found in ABI.", success: false };
+      }
+
+      const selectedWriteFn = selectedAbiWriteFn.name;
+      logSuccess(isExternal, `📜 You selected: ${selectedSig}`);
 
       let writeArgs: any[] = [];
       if (selectedAbiWriteFn.inputs?.length > 0) {
         const argAnswers = await inquirer.prompt(
-          selectedAbiWriteFn.inputs.map((input: any) => ({
+          selectedAbiWriteFn.inputs.map((input: any, idx: number) => ({
             type: "input",
-            name: input.name,
-            message: `Enter value for ${input.name} (${input.type}):`,
+            name: `arg_${idx}`,
+            message: `Enter value for ${input.name || `arg${idx}`} (${input.type}):`,
           }))
         );
         try {
-          writeArgs = selectedAbiWriteFn.inputs.map((input: any) =>
-            coerceArg(argAnswers[input.name], input.type)
+          writeArgs = selectedAbiWriteFn.inputs.map((input: any, idx: number) =>
+            coerceArg(argAnswers[`arg_${idx}`], input.type)
           );
         } catch (err: any) {
           logError(isExternal, `Invalid input: ${err.message}`);
@@ -171,23 +205,36 @@ export async function ReadContract(
             message: "RBTC value to send (e.g. 0.01):",
           },
         ]);
-        const parsed = parseFloat(rbtcValue);
-        if (isNaN(parsed) || parsed <= 0) {
-          logError(isExternal, "Invalid RBTC value. Enter a positive number (e.g. 0.01).");
+        if (!/^\d+(\.\d+)?$/.test(rbtcValue)) {
+          logError(isExternal, "Invalid RBTC value. Use decimal format (e.g. 0.01).");
           return { error: "Invalid RBTC value.", success: false };
         }
-        payableValue = parseEther(rbtcValue);
+        let parsedEther: bigint;
+        try {
+          parsedEther = parseEther(rbtcValue);
+        } catch {
+          logError(isExternal, "Invalid RBTC value. Could not parse amount.");
+          return { error: "Invalid RBTC value.", success: false };
+        }
+        if (parsedEther <= 0n) {
+          logError(isExternal, "RBTC value must be greater than zero.");
+          return { error: "Invalid RBTC value.", success: false };
+        }
+        payableValue = parsedEther;
       }
 
       const provider = new ViemProvider(params.testnet);
       const publicClient = await provider.getPublicClient();
-      const { client: walletClient } = await provider.getWalletClientWithPassword();
+      const { client: walletClient } = await provider.getWalletClientWithPassword(params.wallet);
       const account = walletClient.account!;
 
       if (payableValue !== undefined) {
         const balance = await publicClient.getBalance({ address: account.address });
         if (balance < payableValue) {
-          logError(isExternal, `Insufficient RBTC balance. Have ${formatEther(balance)} RBTC, need ${formatEther(payableValue)} RBTC.`);
+          logError(
+            isExternal,
+            `Insufficient RBTC balance. Have ${formatEther(balance)} RBTC, need ${formatEther(payableValue)} RBTC.`
+          );
           return { error: "Insufficient RBTC balance.", success: false };
         }
       }
@@ -207,19 +254,67 @@ export async function ReadContract(
         simulateRequest = request;
       } catch (err: any) {
         spinner.fail("❌ Simulation failed.");
-        logError(isExternal, err.shortMessage || err.message || "Simulation reverted.");
-        return { error: err.shortMessage || err.message, success: false };
+        const userMsg = isExternal
+          ? "Transaction simulation reverted."
+          : err.shortMessage || err.message || "Simulation reverted.";
+        logError(isExternal, userMsg);
+        return { error: userMsg, success: false };
       }
 
       spinner.succeed("✅ Simulation passed.");
+
+      logInfo(isExternal, `\n📋 Transaction summary:`);
+      logInfo(isExternal, `   Function : ${selectedSig}`);
+      if (writeArgs.length > 0) {
+        logInfo(isExternal, `   Arguments: ${writeArgs.map(String).join(", ")}`);
+      }
+      if (payableValue !== undefined) {
+        logInfo(isExternal, `   Value    : ${formatEther(payableValue)} RBTC`);
+      }
+      logInfo(isExternal, `   Network  : ${params.testnet ? "Rootstock Testnet" : "Rootstock Mainnet"}`);
+
+      const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
+        {
+          type: "confirm",
+          name: "confirmed",
+          message: "Proceed with transaction?",
+          default: false,
+        },
+      ]);
+
+      if (!confirmed) {
+        logWarning(isExternal, "Transaction cancelled by user.");
+        return { error: "Transaction cancelled.", success: false };
+      }
+
       spinner.start("⏳ Submitting transaction...");
 
-      const txHash = await walletClient.writeContract(simulateRequest);
+      let txHash: `0x${string}`;
+      try {
+        txHash = await walletClient.writeContract(simulateRequest);
+      } catch (err: any) {
+        spinner.fail("❌ Submission failed.");
+        logError(isExternal, err.shortMessage || err.message || "Failed to submit transaction.");
+        return { error: err.shortMessage || err.message || "Submission failed.", success: false };
+      }
+
       spinner.stop();
       logSuccess(isExternal, `🔄 Transaction submitted. Hash: ${txHash}`);
 
       spinner.start("⏳ Waiting for confirmation...");
-      const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+      let receipt: any;
+      try {
+        receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+      } catch (err: any) {
+        spinner.stop();
+        logWarning(
+          isExternal,
+          `⚠️  Could not confirm receipt. Check status manually with: rsk-cli tx --txid ${txHash}`
+        );
+        return { error: "Receipt polling failed.", success: false };
+      }
+
       spinner.stop();
 
       const explorerUrl = getExplorerUrl(params.testnet, "tx", txHash);
@@ -255,10 +350,7 @@ export async function ReadContract(
       const errorMessage = "No read functions found in the contract.";
       spinner.stop();
       logWarning(isExternal, errorMessage);
-      return {
-        error: errorMessage,
-        success: false,
-      };
+      return { error: errorMessage, success: false };
     }
 
     spinner.stop();
@@ -370,17 +462,13 @@ export async function ReadContract(
     } catch (error) {
       const errorMessage = `Error while calling function ${selectedFunction}.`;
       spinner.fail(errorMessage);
-      return {
-        error: errorMessage,
-        success: false,
-      };
+      return { error: errorMessage, success: false };
     }
   } catch (error) {
     const errorMessage = "Error during contract interaction.";
     spinner.fail(errorMessage);
-    return {
-      error: errorMessage,
-      success: false,
-    };
+    return { error: errorMessage, success: false };
   }
 }
+
+export const ReadContract = contractCommand;

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -240,7 +240,7 @@ export async function contractCommand(
 
       const provider = new ViemProvider(params.testnet);
       const publicClient = await provider.getPublicClient();
-      const { client: walletClient } = await provider.getWalletClientWithPassword(params.wallet);
+      const walletClient = await provider.getWalletClient(params.wallet);
       if (!walletClient.account) {
         logError(isExternal, "Wallet account not available.");
         return { error: "Wallet account not available.", success: false };

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -1,6 +1,8 @@
 import inquirer from "inquirer";
+import { parseEther, formatEther } from "viem";
 import ViemProvider from "../utils/viemProvider.js";
 import { ContractResult } from "../utils/types.js";
+import { getExplorerUrl } from "../utils/constants.js";
 import { logError, logSuccess, logInfo, logWarning } from "../utils/logger.js";
 import { createSpinner } from "../utils/spinner.js";
 
@@ -12,6 +14,7 @@ type InquirerAnswers = {
 type ContractCommandOptions = {
   address: `0x${string}`;
   testnet: boolean;
+  write?: boolean;
   isExternal?: boolean;
   functionName?: string;
   args?: string[];
@@ -21,6 +24,34 @@ type ContractCommandOptions = {
 function isValidAddress(address: string): boolean {
   const regex = /^0x[a-fA-F0-9]{40}$/;
   return regex.test(address);
+}
+
+function coerceArg(value: string, solidityType: string): any {
+  if (solidityType.endsWith("[]") || solidityType.startsWith("tuple")) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      throw new Error(`Expected JSON for type ${solidityType}, got: ${value}`);
+    }
+  }
+  if (/^u?int(\d+)?$/.test(solidityType)) {
+    return BigInt(value);
+  }
+  if (solidityType === "address") {
+    if (!isValidAddress(value)) throw new Error(`Invalid address: ${value}`);
+    return value;
+  }
+  if (solidityType === "bool") {
+    if (value === "true") return true;
+    if (value === "false") return false;
+    throw new Error(`Invalid bool: "${value}". Use "true" or "false".`);
+  }
+  if (/^bytes(\d+)?$/.test(solidityType)) {
+    if (!/^0x[a-fA-F0-9]*$/.test(value))
+      throw new Error(`Invalid hex for type ${solidityType}: ${value}`);
+    return value;
+  }
+  return value;
 }
 
 export async function ReadContract(
@@ -81,6 +112,138 @@ export async function ReadContract(
     }
 
     const { abi } = resData.data;
+
+    if (params.write) {
+      spinner.stop();
+
+      const writeFunctions = abi.filter(
+        (item: any) =>
+          item.type === "function" &&
+          (item.stateMutability === "nonpayable" ||
+            item.stateMutability === "payable")
+      );
+
+      if (writeFunctions.length === 0) {
+        logWarning(isExternal, "No write functions found in this contract.");
+        return { error: "No write functions found in this contract.", success: false };
+      }
+
+      const { selectedWriteFn } = await inquirer.prompt<{ selectedWriteFn: string }>([
+        {
+          type: "list",
+          name: "selectedWriteFn",
+          message: "Select a write function to call:",
+          choices: writeFunctions.map((item: any) => item.name),
+        },
+      ]);
+
+      logSuccess(isExternal, `📜 You selected: ${selectedWriteFn}`);
+
+      const selectedAbiWriteFn = writeFunctions.find(
+        (item: any) => item.name === selectedWriteFn
+      );
+
+      let writeArgs: any[] = [];
+      if (selectedAbiWriteFn.inputs?.length > 0) {
+        const argAnswers = await inquirer.prompt(
+          selectedAbiWriteFn.inputs.map((input: any) => ({
+            type: "input",
+            name: input.name,
+            message: `Enter value for ${input.name} (${input.type}):`,
+          }))
+        );
+        try {
+          writeArgs = selectedAbiWriteFn.inputs.map((input: any) =>
+            coerceArg(argAnswers[input.name], input.type)
+          );
+        } catch (err: any) {
+          logError(isExternal, `Invalid input: ${err.message}`);
+          return { error: err.message, success: false };
+        }
+      }
+
+      let payableValue: bigint | undefined;
+      if (selectedAbiWriteFn.stateMutability === "payable") {
+        const { rbtcValue } = await inquirer.prompt<{ rbtcValue: string }>([
+          {
+            type: "input",
+            name: "rbtcValue",
+            message: "RBTC value to send (e.g. 0.01):",
+          },
+        ]);
+        const parsed = parseFloat(rbtcValue);
+        if (isNaN(parsed) || parsed <= 0) {
+          logError(isExternal, "Invalid RBTC value. Enter a positive number (e.g. 0.01).");
+          return { error: "Invalid RBTC value.", success: false };
+        }
+        payableValue = parseEther(rbtcValue);
+      }
+
+      const provider = new ViemProvider(params.testnet);
+      const publicClient = await provider.getPublicClient();
+      const { client: walletClient } = await provider.getWalletClientWithPassword();
+      const account = walletClient.account!;
+
+      if (payableValue !== undefined) {
+        const balance = await publicClient.getBalance({ address: account.address });
+        if (balance < payableValue) {
+          logError(isExternal, `Insufficient RBTC balance. Have ${formatEther(balance)} RBTC, need ${formatEther(payableValue)} RBTC.`);
+          return { error: "Insufficient RBTC balance.", success: false };
+        }
+      }
+
+      spinner.start("⏳ Simulating transaction...");
+
+      let simulateRequest: any;
+      try {
+        const { request } = await publicClient.simulateContract({
+          account,
+          address,
+          abi,
+          functionName: selectedWriteFn,
+          args: writeArgs,
+          ...(payableValue !== undefined && { value: payableValue }),
+        });
+        simulateRequest = request;
+      } catch (err: any) {
+        spinner.fail("❌ Simulation failed.");
+        logError(isExternal, err.shortMessage || err.message || "Simulation reverted.");
+        return { error: err.shortMessage || err.message, success: false };
+      }
+
+      spinner.succeed("✅ Simulation passed.");
+      spinner.start("⏳ Submitting transaction...");
+
+      const txHash = await walletClient.writeContract(simulateRequest);
+      spinner.stop();
+      logSuccess(isExternal, `🔄 Transaction submitted. Hash: ${txHash}`);
+
+      spinner.start("⏳ Waiting for confirmation...");
+      const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+      spinner.stop();
+
+      const explorerUrl = getExplorerUrl(params.testnet, "tx", txHash);
+
+      if (receipt.status === "success") {
+        logSuccess(isExternal, "✅ Transaction confirmed!");
+        logInfo(isExternal, `📦 Block: ${receipt.blockNumber}`);
+        logInfo(isExternal, `⛽ Gas used: ${receipt.gasUsed}`);
+        logInfo(isExternal, `🔗 View on Explorer: ${explorerUrl}`);
+        return {
+          success: true,
+          data: {
+            contractAddress: address,
+            network: params.testnet ? "Rootstock Testnet" : "Rootstock Mainnet",
+            functionName: selectedWriteFn,
+            result: txHash,
+            explorerUrl,
+          },
+        };
+      } else {
+        logError(isExternal, "❌ Transaction failed.");
+        return { error: "Transaction failed.", success: false };
+      }
+    }
 
     const readFunctions = abi.filter(
       (item: any) =>

--- a/src/utils/viemProvider.ts
+++ b/src/utils/viemProvider.ts
@@ -82,7 +82,7 @@ class ViemProvider {
     let wallet = wallets[currentWallet];
 
     if (name) {
-      if (!wallets[name]) {
+      if (!Object.hasOwn(wallets, name)) {
         logError(false, "Wallet with the provided name does not exist.");
         throw new Error();
       } else {
@@ -155,7 +155,7 @@ class ViemProvider {
     let walletName = currentWallet;
 
     if (name) {
-      if (!wallets[name]) {
+      if (!Object.hasOwn(wallets, name)) {
         logError(false, "Wallet with the provided name does not exist.");
         throw new Error();
       } else {


### PR DESCRIPTION
Adds a --write flag to the contract command that lets users call nonpayable and payable functions on verified contracts. Includes Solidity type coercion, pre-flight simulation via simulateContract, payable RBTC value handling with balance check, and confirmation receipt with explorer link.