### PR TITLE
Harden devmetrics integration and fix security/CI reliability gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
   11. [Pipe Commands](#11-pipe-commands)
   12. [Transaction Simulation](#12-transaction-simulation)
   13. [RNS Operations](#13-rns-operations)
+  14. [Devmetrics](#14-devmetrics)
 - [Contributing](#contributing)
 
 ## Installation
@@ -1090,7 +1091,6 @@ Output example:
 > - Both checksummed and non-checksummed addresses are supported
 > - The command will show appropriate error messages if the name or address cannot be resolved
 
-<<<<<<< HEAD
 ### 12. Gas Estimator
 
 The `gas` command allows you to estimate gas costs for transactions and contract interactions on the Rootstock blockchain. It provides detailed analysis including gas price, estimated gas limits, and optimization tips.
@@ -1147,12 +1147,70 @@ The command provides:
 - Cost in RBTC and Wei
 - Recommended gas limits (with buffers)
 - Optimization tips (if applicable)
-=======
->>>>>>> main
+
+### 14. Devmetrics
+
+The `devmetrics` command aggregates GitHub repository activity and Rootstock on-chain contract metrics into a single report.
+
+#### Basic Usage
+
+```bash
+rsk-cli devmetrics \
+  --repo rsksmart/rsk-cli \
+  --contract 0x1234567890abcdef1234567890abcdef12345678
+```
+
+#### Multiple Pairs
+
+You can provide multiple `--repo` and `--contract` values. Pairing rules:
+
+- N repos + N contracts: zipped by position
+- N repos + 1 contract: one contract applied to all repos
+- 1 repo + N contracts: one repo applied to all contracts
+
+```bash
+rsk-cli devmetrics \
+  --repo org/repo-a --repo org/repo-b \
+  --contract 0x1111111111111111111111111111111111111111 \
+  --contract 0x2222222222222222222222222222222222222222 \
+  --network testnet
+```
+
+#### Output Formats
+
+```bash
+rsk-cli devmetrics --repo org/repo --contract 0x1234... --format table
+rsk-cli devmetrics --repo org/repo --contract 0x1234... --format json
+rsk-cli devmetrics --repo org/repo --contract 0x1234... --format markdown
+```
+
+#### CI Mode
+
+Use `--ci` for machine-readable JSON envelope output:
+
+```bash
+rsk-cli devmetrics --repo org/repo --contract 0x1234... --ci
+```
+
+Exit codes in CI mode:
+
+- `0`: all pairs succeeded
+- `2`: partial success (some pairs failed)
+- `1`: all pairs failed
+
+#### Security Notes
+
+- Prefer `GITHUB_TOKEN` environment variable over `--github-token` to avoid secret exposure in shell history/process lists.
+- `--rpc-url` only accepts safe HTTP(S) endpoints and blocks private/local/metadata targets by default.
+- Use `--allow-private-rpc` only when you intentionally need localhost/private RPC hosts.
 
 ## Contributing
 
 We welcome contributions from the community. Please fork the repository and submit pull requests with your changes. Ensure your code adheres to the project's main objective.
+
+## Dependency Note
+
+`@ethereum-attestation-service/eas-sdk` is currently pinned to `2.7.0` for compatibility with the existing attestation command flow in this repository. This dependency is not used by the new `devmetrics` command path. A follow-up maintenance pass should retest `2.9.0` compatibility and upgrade when attestation flows are verified stable.
 
 ## Support
 

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -20,7 +20,6 @@ import { configCommand } from "../src/commands/config.js";
 import { transactionCommand } from "../src/commands/transaction.js";
 import { pipeCommand } from "../src/commands/pipe.js";
 import { monitorCommand, listMonitoringSessions, stopMonitoringSession } from "../src/commands/monitor.js";
-import { attestationCommand } from "../src/commands/attestation.js";
 import { gasCommand } from "../src/commands/gas.js";
 import { simulateCommand, TransactionSimulationOptions } from "../src/commands/simulate.js";
 import { parseEther } from "viem";
@@ -29,6 +28,7 @@ import { validateAndFormatAddressRSK } from "../src/utils/index.js";
 import { rnsUpdateCommand } from "../src/commands/rnsUpdate.js";
 import { rnsTransferCommand } from "../src/commands/rnsTransfer.js";
 import { rnsRegisterCommand } from "../src/commands/rnsRegister.js";
+import { devMetricsCommand } from "../src/commands/devmetrics.js";
 
 interface CommandOptions {
   testnet?: boolean;
@@ -81,7 +81,17 @@ interface CommandOptions {
   attestRecipient?: string;
   attestReason?: string;
   rns?: string;
+  repo?: string[];
+  format?: string;
+  ci?: boolean;
+  githubToken?: string;
+  network?: string;
+  rpcUrl?: string;
+  allowPrivateRpc?: boolean;
+  maxPairs?: string;
 }
+
+const collectOption = (value: string, previous: string[]): string[] => [...previous, value];
 
 const orange = chalk.rgb(255, 165, 0);
 
@@ -666,6 +676,79 @@ program
   });
 
 program
+  .command("devmetrics")
+  .description("Aggregate GitHub and Rootstock metrics for repository/contract pairs")
+  .option("-r, --repo <repo>", "GitHub repository in format owner/repo (repeatable)", collectOption, [])
+  .option("-c, --contract <address>", "Rootstock contract address (repeatable)", collectOption, [])
+  .option("-f, --format <format>", "Output format: table, json, or markdown", "table")
+  .option("--ci", "CI mode: machine-readable output", false)
+  .option("--github-token <token>", "GitHub personal access token")
+  .option("--network <network>", "Rootstock network: mainnet or testnet", "mainnet")
+  .option("--rpc-url <url>", "Custom Rootstock RPC URL")
+  .option("--allow-private-rpc", "Allow private/loopback RPC hosts")
+  .option("--max-pairs <number>", "Maximum repo/contract combinations (hard cap: 25)")
+  .action(async (options: CommandOptions) => {
+    const normalizedContracts = Array.isArray(options.contract)
+      ? options.contract
+      : options.contract
+      ? [String(options.contract)]
+      : [];
+
+    const result = await devMetricsCommand({
+      repo: options.repo || [],
+      contract: normalizedContracts,
+      format: options.format,
+      ci: !!options.ci,
+      githubToken: options.githubToken,
+      network: options.network,
+      rpcUrl: options.rpcUrl,
+      allowPrivateRpc: !!options.allowPrivateRpc,
+      maxPairs: options.maxPairs,
+      isExternal: false,
+    });
+
+    if (options.ci) {
+      if (result.data) {
+        console.log(JSON.stringify(result.data, null, 2));
+        const successCount = result.data.meta.successCount;
+        const errorCount = result.data.meta.errorCount;
+        if (successCount > 0 && errorCount === 0) {
+          process.exitCode = 0;
+        } else if (successCount > 0 && errorCount > 0) {
+          process.exitCode = 2;
+        } else {
+          process.exitCode = 1;
+        }
+      } else {
+        console.log(
+          JSON.stringify(
+            {
+              reports: [],
+              errors: [{ error: result.error || "Unknown error" }],
+              meta: {
+                network: options.network === "testnet" ? "testnet" : "mainnet",
+                pairCount: 0,
+                successCount: 0,
+                errorCount: 1,
+                generatedAt: new Date().toISOString(),
+                rpcUrl: "",
+              },
+            },
+            null,
+            2
+          )
+        );
+        process.exitCode = 1;
+      }
+      return;
+    }
+
+    if (!result.success && result.error) {
+      logError(false, `Error during devmetrics: ${result.error}`);
+    }
+  });
+
+program
   .command("attestation")
   .description("Manage attestations on Rootstock using EAS (Ethereum Attestation Service)")
   .requiredOption("--action <action>", "Action to perform: create, verify, revoke, list, schema")
@@ -687,6 +770,8 @@ program
         console.error(chalk.red("🚨 Invalid action. Use: create, verify, revoke, list, or schema"));
         return;
       }
+
+      const { attestationCommand } = await import("../src/commands/attestation.js");
 
       await attestationCommand({
         testnet: !!options.testnet,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ethereum-attestation-service/eas-sdk": "^2.7.0",
+        "@octokit/rest": "^22.0.1",
         "@openzeppelin/contracts": "^5.0.2",
         "@rsksmart/rns-resolver.js": "^1.1.0",
         "@rsksmart/rns-sdk": "^1.0.0-beta.9",
@@ -37,7 +38,8 @@
         "@types/figlet": "^1.5.8",
         "@types/uuid": "^10.0.0",
         "solc": "0.8.28",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "vitest": "^2.1.9"
       },
       "peerDependencies": {
         "typescript": "^5.0.0"
@@ -83,6 +85,397 @@
       "resolved": "https://registry.npmjs.org/@ensdomains/eth-ens-namehash/-/eth-ens-namehash-2.0.15.tgz",
       "integrity": "sha512-JRDFP6+Hczb1E0/HhIg0PONgBYasfGfDheujmfxaZaAv/NAH4jE6Kf48WbqfRZdxt4IZI3jl3Ri7sZ1nP09lgw==",
       "license": "ISC"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@ethereum-attestation-service/eas-contracts": {
       "version": "1.7.1",
@@ -1487,6 +1880,13 @@
         }
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@metamask/abi-utils": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@metamask/abi-utils/-/abi-utils-2.0.4.tgz",
@@ -1876,6 +2276,162 @@
         "node": ">= 12"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
     "node_modules/@openzeppelin/contracts": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.4.0.tgz",
@@ -1891,6 +2447,356 @@
         "@metamask/abi-utils": "^2.0.4",
         "ethereum-cryptography": "^3.0.0"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rsksmart/rns-resolver.js": {
       "version": "1.1.0",
@@ -2086,6 +2992,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/figlet": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@types/figlet/-/figlet-1.7.0.tgz",
@@ -2163,6 +3076,119 @@
       "resolved": "https://registry.npmjs.org/@types/zxcvbn/-/zxcvbn-4.4.5.tgz",
       "integrity": "sha512-FZJgC5Bxuqg7Rhsm/bx6gAruHHhDQ55r+s0JhDh8CQ16fD7NsJJ+p8YMMQDhSQoIrSmjpqqYWA96oQVMNkjRyA==",
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/abitype": {
       "version": "1.2.3",
@@ -2301,6 +3327,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2356,6 +3392,12 @@
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
       "license": "MIT"
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/big-integer": {
       "version": "1.6.36",
@@ -2575,6 +3617,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2634,6 +3686,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -2651,6 +3720,16 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -2916,6 +3995,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -3038,6 +4127,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3048,6 +4144,45 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/escalade": {
@@ -3069,6 +4204,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/eth-ens-namehash": {
@@ -3239,6 +4384,32 @@
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/figlet": {
       "version": "1.10.0",
@@ -4303,6 +5474,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
@@ -4402,11 +5579,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
       "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
       "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -4659,6 +5853,25 @@
       "resolved": "https://registry.npmjs.org/nano-base32/-/nano-base32-1.0.1.tgz",
       "integrity": "sha512-sxEtoTqAPdjWVGv71Q17koMFGsOMSiHsIFEvzOM7cNp8BXB4AnEwmDabm5dorusJf/v1z7QxaZYxUorU9RKaAw==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "2.0.2",
@@ -4961,6 +6174,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/pbkdf2": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
@@ -4977,6 +6207,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
@@ -5006,6 +6243,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/process-nextick-args": {
@@ -5183,6 +6449,51 @@
       "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
       "license": "MIT"
     },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-async": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
@@ -5339,6 +6650,13 @@
         "buffer": "6.0.3"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5402,6 +6720,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -5411,6 +6739,13 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.11",
@@ -5441,6 +6776,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -5527,6 +6869,50 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -5632,6 +7018,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5657,6 +7044,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -5761,6 +7154,155 @@
         }
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -5780,6 +7322,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {
@@ -5828,6 +7387,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "test": "vitest run",
     "dev": "tsc -w",
     "wallet": "pnpm run build && node dist/bin/index.js wallet",
     "balance": "pnpm run build && node dist/bin/index.js balance",
@@ -40,12 +41,14 @@
     "@types/figlet": "^1.5.8",
     "@types/uuid": "^10.0.0",
     "solc": "0.8.28",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^2.1.9"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"
   },
   "dependencies": {
+    "@octokit/rest": "^22.0.1",
     "@ethereum-attestation-service/eas-sdk": "^2.7.0",
     "@openzeppelin/contracts": "^5.0.2",
     "@rsksmart/rns-resolver.js": "^1.1.0",

--- a/src/commands/devmetrics.ts
+++ b/src/commands/devmetrics.ts
@@ -1,0 +1,188 @@
+import { createSpinner } from "../utils/spinner.js";
+import { logError, logInfo, logWarning } from "../utils/logger.js";
+import {
+  DevMetricsCommandOptions,
+  DevMetricsCommandResult,
+  DevMetricsOutputFormat,
+  DevMetricsReport,
+} from "../types/devmetrics.js";
+import { validateRpcUrl, redactRpcUrl } from "../utils/devmetrics/rpcUrl.js";
+import {
+  buildPairs,
+  parseAndValidateMaxPairs,
+  parseRepoIdentifier,
+  validateContractAddress,
+  validateOutputFormat,
+  validateRepo,
+} from "../utils/devmetrics/validation.js";
+import { GitHubService } from "../services/devmetrics/githubService.js";
+import { Network, RootstockService } from "../services/devmetrics/rootstockService.js";
+import { formatDevMetricsReport } from "../formatters/devmetrics/index.js";
+
+export async function devMetricsCommand(params: DevMetricsCommandOptions): Promise<DevMetricsCommandResult> {
+  const isExternal = params.isExternal || !!params.ci;
+  const spinner = createSpinner(isExternal);
+
+  try {
+    const network: Network = params.network?.toLowerCase() === "testnet" ? "testnet" : "mainnet";
+    if (params.network && !["mainnet", "testnet"].includes(params.network.toLowerCase())) {
+      return { success: false, error: `Invalid network: ${params.network}. Must be 'mainnet' or 'testnet'.` };
+    }
+
+    let outputFormat: DevMetricsOutputFormat = "table";
+    if (params.ci) {
+      outputFormat = "json";
+    } else if (params.format) {
+      outputFormat = validateOutputFormat(params.format) ? params.format : "table";
+    }
+
+    if (!params.ci && params.format && !validateOutputFormat(params.format)) {
+      return { success: false, error: `Invalid format: ${params.format}. Must be table, json, or markdown.` };
+    }
+
+    if (!params.repo?.length) {
+      return { success: false, error: "At least one --repo value is required." };
+    }
+
+    if (!params.contract?.length) {
+      return { success: false, error: "At least one --contract value is required." };
+    }
+
+    const { pairs, error: pairingError } = buildPairs(params.repo, params.contract);
+    if (pairingError) {
+      return { success: false, error: pairingError };
+    }
+
+    const { maxPairs, error: maxPairsError } = parseAndValidateMaxPairs(params.maxPairs);
+    if (maxPairsError) {
+      return { success: false, error: maxPairsError };
+    }
+
+    if (pairs.length > maxPairs) {
+      return {
+        success: false,
+        error: `Too many repo/contract combinations (${pairs.length}); max is ${maxPairs}.`,
+      };
+    }
+
+    for (const pair of pairs) {
+      const repoValidation = validateRepo(pair.repo);
+      if (!repoValidation.valid) {
+        return { success: false, error: `Repository "${pair.repo}": ${repoValidation.error}` };
+      }
+      const contractValidation = validateContractAddress(pair.contract);
+      if (!contractValidation.valid) {
+        return { success: false, error: `Contract "${pair.contract}": ${contractValidation.error}` };
+      }
+    }
+
+    const effectiveRpcUrl =
+      params.rpcUrl ||
+      (network === "testnet"
+        ? process.env.ROOTSTOCK_TESTNET_RPC_URL || "https://public-node.testnet.rsk.co"
+        : process.env.ROOTSTOCK_MAINNET_RPC_URL || "https://public-node.rsk.co");
+
+    await validateRpcUrl(effectiveRpcUrl, { allowPrivateRpc: !!params.allowPrivateRpc });
+
+    if (params.githubToken) {
+      const trimmedToken = params.githubToken.trim();
+      const tokenPattern = /^[A-Za-z0-9_]+$/;
+      if (trimmedToken.length < 20 || trimmedToken.length > 255 || !tokenPattern.test(trimmedToken)) {
+        return {
+          success: false,
+          error: "Invalid --github-token format. Use a valid token or set GITHUB_TOKEN env var.",
+        };
+      }
+      if (!params.ci) {
+        logWarning(
+          isExternal,
+          "Using --github-token may expose secrets in shell history/process lists. Prefer GITHUB_TOKEN environment variable."
+        );
+      }
+    }
+
+    const githubService = new GitHubService(params.githubToken);
+    const rootstockService = await RootstockService.create(effectiveRpcUrl, network, !!params.allowPrivateRpc);
+
+    if (outputFormat === "table") {
+      logInfo(isExternal, `Rootstock Network: ${network.toUpperCase()}`);
+      logInfo(isExternal, `RPC URL: ${rootstockService.getRedactedRpcUrl()}`);
+      if (!githubService.isAuthenticated()) {
+        logWarning(
+          isExternal,
+          "No GitHub token detected. Unauthenticated mode has strict rate limits. Set GITHUB_TOKEN for higher throughput."
+        );
+      }
+    }
+
+    const reports: DevMetricsReport[] = [];
+    const errors: Array<{ pair: { repo: string; contract: string }; error: string }> = [];
+
+    for (const pair of pairs) {
+      const parsedRepo = parseRepoIdentifier(pair.repo);
+      if (!parsedRepo.owner || !parsedRepo.repo) {
+        errors.push({
+          pair,
+          error: parsedRepo.error || `Invalid repository identifier "${pair.repo}"`,
+        });
+        continue;
+      }
+
+      spinner.start(`Fetching metrics for ${pair.repo}...`);
+      try {
+        const github = await githubService.getMetrics(parsedRepo.owner, parsedRepo.repo);
+        const rootstock = await rootstockService.getMetrics(pair.contract);
+
+        reports.push({
+          repository: pair.repo,
+          contractAddress: pair.contract,
+          github,
+          rootstock,
+          timestamp: new Date().toISOString(),
+        });
+        spinner.succeed(`Fetched metrics for ${pair.repo}`);
+      } catch (error: any) {
+        spinner.fail(`Failed metrics for ${pair.repo}`);
+        errors.push({
+          pair,
+          error: error?.message || "Unknown error",
+        });
+      }
+    }
+
+    const resultData = {
+      reports,
+      errors,
+      meta: {
+        network,
+        pairCount: pairs.length,
+        successCount: reports.length,
+        errorCount: errors.length,
+        generatedAt: new Date().toISOString(),
+        rpcUrl: redactRpcUrl(effectiveRpcUrl),
+      },
+    };
+
+    if (!isExternal && reports.length > 0 && !params.ci) {
+      const formatted = formatDevMetricsReport(reports, outputFormat);
+      logInfo(isExternal, formatted);
+    }
+
+    if (!isExternal && errors.length > 0 && !params.ci) {
+      for (const item of errors) {
+        logError(isExternal, `${item.pair.repo} / ${item.pair.contract}: ${item.error}`);
+      }
+    }
+
+    return {
+      success: reports.length > 0,
+      data: resultData,
+      error: reports.length === 0 ? "No reports were generated." : undefined,
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error?.message || "Failed to run devmetrics command",
+    };
+  }
+}

--- a/src/formatters/devmetrics/index.ts
+++ b/src/formatters/devmetrics/index.ts
@@ -1,0 +1,19 @@
+import { DevMetricsReport, DevMetricsOutputFormat } from "../../types/devmetrics.js";
+import { formatAsJSON } from "./json.js";
+import { formatAsMarkdown } from "./markdown.js";
+import { formatAsTable } from "./table.js";
+
+export function formatDevMetricsReport(
+  reports: DevMetricsReport[],
+  format: DevMetricsOutputFormat
+): string {
+  switch (format) {
+    case "json":
+      return formatAsJSON(reports);
+    case "markdown":
+      return formatAsMarkdown(reports);
+    case "table":
+    default:
+      return formatAsTable(reports);
+  }
+}

--- a/src/formatters/devmetrics/json.ts
+++ b/src/formatters/devmetrics/json.ts
@@ -1,0 +1,5 @@
+import { DevMetricsReport } from "../../types/devmetrics.js";
+
+export function formatAsJSON(reports: DevMetricsReport[]): string {
+  return JSON.stringify(reports, null, 2);
+}

--- a/src/formatters/devmetrics/markdown.ts
+++ b/src/formatters/devmetrics/markdown.ts
@@ -1,0 +1,47 @@
+import { DevMetricsReport } from "../../types/devmetrics.js";
+
+export function formatAsMarkdown(reports: DevMetricsReport[]): string {
+  const output: string[] = [];
+
+  for (const report of reports) {
+    output.push(`# Developer Health Report: ${report.repository}`);
+    output.push("");
+    output.push(`**Contract Address:** \`${report.contractAddress}\``);
+    output.push(`**Generated:** ${new Date(report.timestamp).toLocaleString()}`);
+    output.push("");
+
+    output.push("## GitHub Metrics");
+    output.push("");
+    output.push("| Metric | Value |");
+    output.push("|--------|-------|");
+    output.push(`| Stars | ${report.github.stars} |`);
+    output.push(
+      `| Last Commit | ${report.github.lastCommitDate ? new Date(report.github.lastCommitDate).toLocaleDateString() : "N/A"} |`
+    );
+    output.push(`| Open Issues | ${report.github.openIssuesCount} |`);
+    output.push(`| Open PRs | ${report.github.pullRequestsCount} |`);
+    output.push(`| Contributors | ${report.github.contributorCount} |`);
+    output.push("");
+
+    output.push("## Rootstock Metrics");
+    output.push("");
+    output.push("| Metric | Value |");
+    output.push("|--------|-------|");
+    output.push(`| Deployment Block | ${report.rootstock.deploymentBlock ?? "N/A"} |`);
+    output.push(`| Total Transactions | ${report.rootstock.totalTransactionCount} |`);
+    output.push(
+      `| Last Transaction | ${report.rootstock.lastTransactionTimestamp ? new Date(report.rootstock.lastTransactionTimestamp).toLocaleDateString() : "N/A"} |`
+    );
+    output.push(`| Average Gas Usage | ${report.rootstock.gasUsagePatterns.average.toLocaleString()} |`);
+    output.push(`| Min Gas Usage | ${report.rootstock.gasUsagePatterns.min.toLocaleString()} |`);
+    output.push(`| Max Gas Usage | ${report.rootstock.gasUsagePatterns.max.toLocaleString()} |`);
+    output.push("");
+
+    if (reports.length > 1) {
+      output.push("---");
+      output.push("");
+    }
+  }
+
+  return output.join("\n");
+}

--- a/src/formatters/devmetrics/table.ts
+++ b/src/formatters/devmetrics/table.ts
@@ -1,0 +1,50 @@
+import Table from "cli-table3";
+import chalk from "chalk";
+import { DevMetricsReport } from "../../types/devmetrics.js";
+
+export function formatAsTable(reports: DevMetricsReport[]): string {
+  const output: string[] = [];
+
+  for (const report of reports) {
+    output.push(chalk.bold.cyan(`\nReport for ${report.repository}`));
+    output.push(chalk.gray(`Contract: ${report.contractAddress}`));
+    output.push(chalk.gray(`Generated: ${new Date(report.timestamp).toLocaleString()}\n`));
+
+    const githubTable = new Table({
+      head: [chalk.blue("GitHub Metrics"), chalk.yellow("Value")],
+      style: { head: [], border: [] },
+    });
+
+    githubTable.push(
+      ["Stars", String(report.github.stars)],
+      ["Last Commit", report.github.lastCommitDate ? new Date(report.github.lastCommitDate).toLocaleDateString() : "N/A"],
+      ["Open Issues", String(report.github.openIssuesCount)],
+      ["Open PRs", String(report.github.pullRequestsCount)],
+      ["Contributors", String(report.github.contributorCount)]
+    );
+
+    const rootstockTable = new Table({
+      head: [chalk.blue("Rootstock Metrics"), chalk.yellow("Value")],
+      style: { head: [], border: [] },
+    });
+
+    rootstockTable.push(
+      ["Deployment Block", report.rootstock.deploymentBlock?.toString() || "N/A"],
+      ["Total Transactions", String(report.rootstock.totalTransactionCount)],
+      [
+        "Last Transaction",
+        report.rootstock.lastTransactionTimestamp
+          ? new Date(report.rootstock.lastTransactionTimestamp).toLocaleDateString()
+          : "N/A",
+      ],
+      ["Avg Gas Usage", report.rootstock.gasUsagePatterns.average.toLocaleString()],
+      ["Min Gas Usage", report.rootstock.gasUsagePatterns.min.toLocaleString()],
+      ["Max Gas Usage", report.rootstock.gasUsagePatterns.max.toLocaleString()]
+    );
+
+    output.push(githubTable.toString());
+    output.push("\n" + rootstockTable.toString());
+  }
+
+  return output.join("\n");
+}

--- a/src/services/devmetrics/githubService.ts
+++ b/src/services/devmetrics/githubService.ts
@@ -1,0 +1,143 @@
+import { Octokit } from "@octokit/rest";
+import { GitHubMetrics } from "../../types/devmetrics.js";
+
+type OctokitLike = Octokit;
+
+export class GitHubService {
+  private octokit: OctokitLike;
+  private hasToken: boolean;
+  private readonly apiTimeoutMs = 15000;
+  private readonly totalTimeoutMs = 60000;
+
+  constructor(token?: string) {
+    const authToken = token || process.env.GITHUB_TOKEN;
+    this.hasToken = !!authToken;
+    this.octokit = this.createOctokit(authToken);
+  }
+
+  private createOctokit(authToken?: string): OctokitLike {
+    const noopLogger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+    return new Octokit({
+      auth: authToken,
+      log: noopLogger,
+      request: {
+        timeout: this.apiTimeoutMs,
+      },
+    });
+  }
+
+  isAuthenticated(): boolean {
+    return this.hasToken;
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, timeoutMs: number = this.apiTimeoutMs): Promise<T> {
+    return Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        setTimeout(() => reject(new Error(`GitHub API call timed out after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  }
+
+  async getMetrics(owner: string, repo: string): Promise<GitHubMetrics> {
+    return this.withTimeout(this.getMetricsWithFallback(owner, repo), this.totalTimeoutMs);
+  }
+
+  private async getMetricsWithFallback(owner: string, repo: string): Promise<GitHubMetrics> {
+    try {
+      return await this.fetchMetrics(owner, repo);
+    } catch (error: any) {
+      if (error?.status === 401 && this.hasToken) {
+        this.hasToken = false;
+        this.octokit = this.createOctokit(undefined);
+        return this.fetchMetrics(owner, repo);
+      }
+      throw this.normalizeError(error, owner, repo);
+    }
+  }
+
+  private async fetchMetrics(owner: string, repo: string): Promise<GitHubMetrics> {
+    const { data: repoData } = await this.withTimeout(this.octokit.repos.get({ owner, repo }));
+
+    const { data: commits } = await this.withTimeout(
+      this.octokit.repos.listCommits({
+        owner,
+        repo,
+        per_page: 1,
+      })
+    );
+
+    const { data: pullRequests } = await this.withTimeout(
+      this.octokit.pulls.list({
+        owner,
+        repo,
+        state: "open",
+        per_page: 1,
+      })
+    );
+
+    let prsCount = 0;
+    try {
+      const { data: prSearch } = await this.withTimeout(
+        this.octokit.search.issuesAndPullRequests({
+          q: `repo:${owner}/${repo} type:pr state:open`,
+          per_page: 1,
+        })
+      );
+      prsCount = prSearch.total_count || 0;
+    } catch {
+      prsCount = pullRequests.length;
+    }
+
+    let contributorsCount = 0;
+    try {
+      const { data: contributors } = await this.withTimeout(
+        this.octokit.repos.listContributors({
+          owner,
+          repo,
+          per_page: this.hasToken ? 100 : 30,
+        })
+      );
+      contributorsCount = contributors.length;
+    } catch {
+      contributorsCount = 0;
+    }
+
+    return {
+      stars: repoData.stargazers_count || 0,
+      lastCommitDate: commits[0]?.commit.committer?.date || null,
+      openIssuesCount: repoData.open_issues_count || 0,
+      pullRequestsCount: prsCount,
+      contributorCount: contributorsCount,
+      repository: `${owner}/${repo}`,
+    };
+  }
+
+  private normalizeError(error: any, owner: string, repo: string): Error {
+    if (error?.status === 404) {
+      return new Error(`Repository ${owner}/${repo} not found`);
+    }
+
+    if (error?.status === 403) {
+      const resetTime = error?.response?.headers?.["x-ratelimit-reset"];
+      let message = "GitHub API rate limit exceeded.";
+      if (this.hasToken) {
+        message += " Token-authenticated limit was reached.";
+      } else {
+        message += " Add GITHUB_TOKEN for higher rate limits.";
+      }
+      if (resetTime) {
+        const resetDate = new Date(Number.parseInt(resetTime, 10) * 1000);
+        message += ` Rate limit resets at: ${resetDate.toLocaleString()}`;
+      }
+      return new Error(message);
+    }
+
+    return new Error(`Failed to fetch GitHub metrics: ${error?.message || "Unknown error"}`);
+  }
+}

--- a/src/services/devmetrics/rootstockService.ts
+++ b/src/services/devmetrics/rootstockService.ts
@@ -1,0 +1,252 @@
+import { Address, createPublicClient, getAddress, Hex, http, PublicClient } from "viem";
+import { rootstock, rootstockTestnet } from "viem/chains";
+import { GasUsagePatterns, RootstockMetrics } from "../../types/devmetrics.js";
+import { redactRpcUrl, validateRpcUrl } from "../../utils/devmetrics/rpcUrl.js";
+
+export type Network = "mainnet" | "testnet";
+
+export class RootstockService {
+  private readonly client: PublicClient;
+  private readonly network: Network;
+  private readonly rpcUrl: string;
+
+  private readonly rpcTimeoutMs = 5000;
+  private readonly totalTimeoutMs = 45000;
+  private readonly maxDeploymentSearchBlocks = 10000;
+  private readonly maxTransactionSearchBlocks = 2000;
+
+  private constructor(rpcUrl: string, network: Network) {
+    this.network = network;
+    this.rpcUrl = rpcUrl;
+    this.client = createPublicClient({
+      chain: this.network === "testnet" ? rootstockTestnet : rootstock,
+      transport: http(this.rpcUrl),
+    });
+  }
+
+  static async create(rpcUrl?: string, network?: Network, allowPrivateRpc: boolean = false): Promise<RootstockService> {
+    const resolvedNetwork = network || (rpcUrl && rpcUrl.includes("testnet") ? "testnet" : "mainnet");
+    const resolvedRpcUrl =
+      rpcUrl ||
+      (resolvedNetwork === "testnet"
+        ? process.env.ROOTSTOCK_TESTNET_RPC_URL || "https://public-node.testnet.rsk.co"
+        : process.env.ROOTSTOCK_MAINNET_RPC_URL || "https://public-node.rsk.co");
+
+    await validateRpcUrl(resolvedRpcUrl, { allowPrivateRpc });
+    return new RootstockService(resolvedRpcUrl, resolvedNetwork);
+  }
+
+  getNetwork(): Network {
+    return this.network;
+  }
+
+  getRedactedRpcUrl(): string {
+    return redactRpcUrl(this.rpcUrl);
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, timeoutMs: number = this.rpcTimeoutMs): Promise<T> {
+    return Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        setTimeout(() => reject(new Error(`RPC call timed out after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  }
+
+  async getMetrics(contractAddress: string): Promise<RootstockMetrics> {
+    return this.withTimeout(this.fetchMetrics(contractAddress), this.totalTimeoutMs);
+  }
+
+  private async fetchMetrics(contractAddress: string): Promise<RootstockMetrics> {
+    try {
+      const normalizedAddress = getAddress(contractAddress) as Address;
+      const currentBlockBigInt = await this.withTimeout(this.client.getBlockNumber(), 5000);
+      const currentBlock = Number(currentBlockBigInt);
+      const deploymentBlock = await this.getDeploymentBlock(normalizedAddress, currentBlock);
+
+      if (!deploymentBlock) {
+        return {
+          contractAddress: normalizedAddress,
+          deploymentBlock: null,
+          totalTransactionCount: 0,
+          lastTransactionTimestamp: null,
+          gasUsagePatterns: { average: 0, min: 0, max: 0 },
+        };
+      }
+
+      const [transactionCount, lastTransaction, gasUsagePatterns] = await Promise.allSettled([
+        this.getTransactionCount(normalizedAddress, deploymentBlock, currentBlock),
+        this.getLastTransaction(normalizedAddress, deploymentBlock, currentBlock),
+        this.getGasUsagePatterns(normalizedAddress, deploymentBlock, currentBlock),
+      ]);
+
+      return {
+        contractAddress: normalizedAddress,
+        deploymentBlock,
+        totalTransactionCount: transactionCount.status === "fulfilled" ? transactionCount.value : 0,
+        lastTransactionTimestamp: lastTransaction.status === "fulfilled" ? lastTransaction.value : null,
+        gasUsagePatterns:
+          gasUsagePatterns.status === "fulfilled"
+            ? gasUsagePatterns.value
+            : { average: 0, min: 0, max: 0 },
+      };
+    } catch (error: any) {
+      throw new Error(`Failed to fetch Rootstock metrics: ${error?.message || "Unknown error"}`);
+    }
+  }
+
+  private async getDeploymentBlock(contractAddress: Address, currentBlock: number): Promise<number | null> {
+    const searchStartBlock = Math.max(0, currentBlock - this.maxDeploymentSearchBlocks);
+
+    try {
+      const bytecode = await this.withTimeout(this.client.getBytecode({ address: contractAddress }), 5000);
+      if (!bytecode || bytecode === "0x") return null;
+      return this.binarySearchDeployment(contractAddress, searchStartBlock, currentBlock);
+    } catch {
+      return null;
+    }
+  }
+
+  private async binarySearchDeployment(contractAddress: Address, low: number, high: number): Promise<number> {
+    let left = low;
+    let right = high;
+    let iterations = 0;
+    const maxIterations = 18;
+
+    while (left < right && iterations < maxIterations) {
+      iterations += 1;
+      const mid = Math.floor((left + right) / 2);
+      try {
+        const code = await this.withTimeout(
+          this.client.getBytecode({ address: contractAddress, blockNumber: BigInt(mid) }),
+          3000
+        );
+        if (code && code !== "0x") {
+          right = mid;
+        } else {
+          left = mid + 1;
+        }
+      } catch {
+        return left;
+      }
+    }
+
+    return left;
+  }
+
+  private async getTransactionCount(contractAddress: Address, deploymentBlock: number, currentBlock: number): Promise<number> {
+    const searchEndBlock = Math.min(currentBlock, deploymentBlock + this.maxTransactionSearchBlocks);
+    const sampleSize = 20;
+    const step = Math.max(1, Math.floor((searchEndBlock - deploymentBlock) / sampleSize));
+    let count = 0;
+    let checked = 0;
+
+    for (let block = deploymentBlock; block <= searchEndBlock && checked < sampleSize; block += step) {
+      try {
+        const blockData = await this.withTimeout(
+          this.client.getBlock({ blockNumber: BigInt(block), includeTransactions: true }),
+          3000
+        );
+        const txs = blockData.transactions as Array<{ to: Address | null } | Hex>;
+        const matches = txs.filter((tx) => {
+          if (typeof tx === "string") return false;
+          return tx.to?.toLowerCase() === contractAddress.toLowerCase();
+        }).length;
+        count += matches;
+        checked += 1;
+      } catch {
+        continue;
+      }
+    }
+
+    if (checked > 0 && step > 1) {
+      const averagePerSample = count / checked;
+      const totalBlocks = searchEndBlock - deploymentBlock + 1;
+      return Math.round(averagePerSample * totalBlocks);
+    }
+
+    return count;
+  }
+
+  private async getLastTransaction(contractAddress: Address, deploymentBlock: number, currentBlock: number): Promise<string | null> {
+    const searchStep = 100;
+    const maxChecks = 20;
+    const searchStartBlock = Math.max(deploymentBlock, currentBlock - 500);
+
+    for (let i = 0; i < maxChecks; i++) {
+      const block = currentBlock - i * searchStep;
+      if (block < searchStartBlock) break;
+
+      try {
+        const blockData = await this.withTimeout(
+          this.client.getBlock({ blockNumber: BigInt(block), includeTransactions: true }),
+          3000
+        );
+        const txs = blockData.transactions as Array<{ to: Address | null } | Hex>;
+        const found = txs.find((tx) => {
+          if (typeof tx === "string") return false;
+          return tx.to?.toLowerCase() === contractAddress.toLowerCase();
+        });
+        if (found) {
+          return new Date(Number(blockData.timestamp) * 1000).toISOString();
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return null;
+  }
+
+  private async getGasUsagePatterns(
+    contractAddress: Address,
+    deploymentBlock: number,
+    currentBlock: number
+  ): Promise<GasUsagePatterns> {
+    const gasUsages: number[] = [];
+    const sampleSize = 20;
+    const searchStep = 50;
+    const maxChecks = 10;
+    const searchStartBlock = Math.max(deploymentBlock, currentBlock - 200);
+
+    for (let i = 0; i < maxChecks && gasUsages.length < sampleSize; i++) {
+      const block = currentBlock - i * searchStep;
+      if (block < searchStartBlock) break;
+
+      try {
+        const blockData = await this.withTimeout(
+          this.client.getBlock({ blockNumber: BigInt(block), includeTransactions: true }),
+          3000
+        );
+        const txs = blockData.transactions as Array<{ hash: Hex; to: Address | null } | Hex>;
+        const matched = txs.filter((tx) => {
+          if (typeof tx === "string") return false;
+          return tx.to?.toLowerCase() === contractAddress.toLowerCase();
+        });
+
+        for (const tx of matched) {
+          if (typeof tx === "string" || gasUsages.length >= sampleSize) continue;
+          try {
+            const receipt = await this.withTimeout(this.client.getTransactionReceipt({ hash: tx.hash }), 3000);
+            gasUsages.push(Number(receipt.gasUsed));
+          } catch {
+            continue;
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    if (gasUsages.length === 0) {
+      return { average: 0, min: 0, max: 0 };
+    }
+
+    const sum = gasUsages.reduce((a, b) => a + b, 0);
+    return {
+      average: Math.round(sum / gasUsages.length),
+      min: Math.min(...gasUsages),
+      max: Math.max(...gasUsages),
+    };
+  }
+}

--- a/src/types/devmetrics.ts
+++ b/src/types/devmetrics.ts
@@ -1,0 +1,76 @@
+export type DevMetricsOutputFormat = "table" | "json" | "markdown";
+
+export type GitHubMetrics = {
+  stars: number;
+  lastCommitDate: string | null;
+  openIssuesCount: number;
+  pullRequestsCount: number;
+  contributorCount: number;
+  repository: string;
+};
+
+export type GasUsagePatterns = {
+  average: number;
+  min: number;
+  max: number;
+};
+
+export type RootstockMetrics = {
+  contractAddress: string;
+  deploymentBlock: number | null;
+  totalTransactionCount: number;
+  lastTransactionTimestamp: string | null;
+  gasUsagePatterns: GasUsagePatterns;
+};
+
+export type DevMetricsReport = {
+  repository: string;
+  contractAddress: string;
+  github: GitHubMetrics;
+  rootstock: RootstockMetrics;
+  timestamp: string;
+};
+
+export type DevMetricsPair = {
+  repo: string;
+  contract: string;
+};
+
+export type DevMetricsError = {
+  pair: DevMetricsPair;
+  error: string;
+};
+
+export type DevMetricsMeta = {
+  network: "mainnet" | "testnet";
+  pairCount: number;
+  successCount: number;
+  errorCount: number;
+  generatedAt: string;
+  rpcUrl: string;
+};
+
+export type DevMetricsResultData = {
+  reports: DevMetricsReport[];
+  errors: DevMetricsError[];
+  meta: DevMetricsMeta;
+};
+
+export type DevMetricsCommandResult = {
+  success: boolean;
+  data?: DevMetricsResultData;
+  error?: string;
+};
+
+export type DevMetricsCommandOptions = {
+  repo: string[];
+  contract: string[];
+  format?: string;
+  ci?: boolean;
+  githubToken?: string;
+  network?: string;
+  rpcUrl?: string;
+  allowPrivateRpc?: boolean;
+  maxPairs?: string;
+  isExternal?: boolean;
+};

--- a/src/utils/devmetrics/rpcUrl.ts
+++ b/src/utils/devmetrics/rpcUrl.ts
@@ -1,0 +1,143 @@
+import dns from "node:dns/promises";
+import net from "node:net";
+
+type RpcValidationOptions = {
+  allowPrivateRpc?: boolean;
+};
+
+function ipv4ToInt(ip: string): number {
+  const parts = ip.split(".").map((p) => Number.parseInt(p, 10));
+  return ((parts[0] << 24) >>> 0) + ((parts[1] << 16) >>> 0) + ((parts[2] << 8) >>> 0) + parts[3];
+}
+
+function isInCidr(ip: string, cidrBase: string, maskBits: number): boolean {
+  const mask = maskBits === 0 ? 0 : (~((1 << (32 - maskBits)) - 1) >>> 0);
+  return (ipv4ToInt(ip) & mask) === (ipv4ToInt(cidrBase) & mask);
+}
+
+function isDisallowedIpv4(ip: string, allowPrivateRpc: boolean): boolean {
+  if (ip === "169.254.169.254") return true;
+
+  const alwaysBlockedCidrs: Array<[string, number]> = [
+    ["0.0.0.0", 8],
+    ["169.254.0.0", 16],
+    ["224.0.0.0", 4],
+    ["240.0.0.0", 4],
+  ];
+
+  const privateCidrs: Array<[string, number]> = [
+    ["127.0.0.0", 8],
+    ["10.0.0.0", 8],
+    ["172.16.0.0", 12],
+    ["192.168.0.0", 16],
+  ];
+
+  if (alwaysBlockedCidrs.some(([base, bits]) => isInCidr(ip, base, bits))) return true;
+  if (!allowPrivateRpc && privateCidrs.some(([base, bits]) => isInCidr(ip, base, bits))) return true;
+  return false;
+}
+
+function isDisallowedIpv6(rawIp: string, allowPrivateRpc: boolean): boolean {
+  const ip = rawIp.toLowerCase();
+  if (ip === "::") return true;
+  if (!allowPrivateRpc && ip === "::1") return true;
+  if (ip.startsWith("fe80:")) return true;
+  if (!allowPrivateRpc && (ip.startsWith("fc") || ip.startsWith("fd"))) return true;
+
+  if (ip.startsWith("::ffff:")) {
+    const mapped = ip.replace("::ffff:", "");
+    if (net.isIPv4(mapped)) return isDisallowedIpv4(mapped, allowPrivateRpc);
+  }
+
+  return false;
+}
+
+function isDisallowedIp(ip: string, allowPrivateRpc: boolean): boolean {
+  const version = net.isIP(ip);
+  if (version === 4) return isDisallowedIpv4(ip, allowPrivateRpc);
+  if (version === 6) return isDisallowedIpv6(ip, allowPrivateRpc);
+  return false;
+}
+
+function baseUrlError(rawUrl: string, reason: string): Error {
+  return new Error(`Invalid RPC URL "${rawUrl}": ${reason}`);
+}
+
+export function validateRpcUrlLiteral(rawUrl: string, options: RpcValidationOptions = {}): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw baseUrlError(rawUrl, "must be a valid absolute URL");
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw baseUrlError(rawUrl, "only http and https schemes are allowed");
+  }
+
+  if (!parsed.hostname) {
+    throw baseUrlError(rawUrl, "hostname is required");
+  }
+
+  const isLiteralIp = net.isIP(parsed.hostname) !== 0;
+  if (isLiteralIp && isDisallowedIp(parsed.hostname, !!options.allowPrivateRpc)) {
+    throw baseUrlError(rawUrl, "target IP range is blocked by SSRF policy");
+  }
+
+  return parsed;
+}
+
+export async function validateRpcUrl(rawUrl: string, options: RpcValidationOptions = {}): Promise<URL> {
+  const parsed = validateRpcUrlLiteral(rawUrl, options);
+  const hostname = parsed.hostname;
+
+  if (net.isIP(hostname) !== 0) return parsed;
+
+  let records: Array<{ address: string; family: number }>;
+  try {
+    records = (await dns.lookup(hostname, { all: true })) as Array<{ address: string; family: number }>;
+  } catch {
+    throw baseUrlError(rawUrl, "hostname could not be resolved");
+  }
+
+  if (records.length === 0) {
+    throw baseUrlError(rawUrl, "hostname resolved to no addresses");
+  }
+
+  const allowPrivateRpc = !!options.allowPrivateRpc;
+  const hasBlockedAddress = records.some((record) => isDisallowedIp(record.address, allowPrivateRpc));
+  if (hasBlockedAddress) {
+    throw baseUrlError(rawUrl, "hostname resolves to a blocked private or local address");
+  }
+
+  return parsed;
+}
+
+export function redactRpcUrl(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl);
+    parsed.username = "";
+    parsed.password = "";
+
+    const sensitiveQueryKeys = ["key", "api_key", "apikey", "token", "access_token", "auth", "secret"];
+    const queryEntries = [...parsed.searchParams.entries()];
+    for (const [key, value] of queryEntries) {
+      const lowerKey = key.toLowerCase();
+      const isSensitiveKey = sensitiveQueryKeys.includes(lowerKey);
+      const looksLikeSecretValue =
+        value.length >= 20 && /^[A-Za-z0-9._-]+$/.test(value) && !/^(true|false|\d+)$/i.test(value);
+
+      if (isSensitiveKey || looksLikeSecretValue) {
+        parsed.searchParams.set(key, "****");
+      }
+    }
+
+    parsed.pathname = parsed.pathname
+      .replace(/\/v3\/[^/]+/i, "/v3/****")
+      .replace(/\/(api[-_]?key|token)\/[^/]+/gi, "/$1/****");
+
+    return parsed.toString();
+  } catch {
+    return "invalid-rpc-url";
+  }
+}

--- a/src/utils/devmetrics/validation.ts
+++ b/src/utils/devmetrics/validation.ts
@@ -1,0 +1,90 @@
+import { DevMetricsOutputFormat, DevMetricsPair } from "../../types/devmetrics.js";
+
+const REPO_REGEX = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
+const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+const HARD_MAX_PAIRS = 25;
+
+export function validateRepo(repo: string): { valid: boolean; error?: string } {
+  if (!REPO_REGEX.test(repo)) {
+    return { valid: false, error: "Repository must be in format owner/repo" };
+  }
+  return { valid: true };
+}
+
+export function validateContractAddress(address: string): { valid: boolean; error?: string } {
+  if (!ADDRESS_REGEX.test(address)) {
+    return {
+      valid: false,
+      error: "Contract address must be a valid 0x-prefixed 40 hex string",
+    };
+  }
+  return { valid: true };
+}
+
+export function validateOutputFormat(format: string): format is DevMetricsOutputFormat {
+  return format === "table" || format === "json" || format === "markdown";
+}
+
+export function parseRepoIdentifier(
+  repoIdentifier: string
+): { owner?: string; repo?: string; error?: string } {
+  const trimmed = repoIdentifier.trim();
+  const parts = trimmed.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return { error: `Invalid repository identifier "${repoIdentifier}"` };
+  }
+  return { owner: parts[0], repo: parts[1] };
+}
+
+export function buildPairs(repos: string[], contracts: string[]): {
+  pairs: DevMetricsPair[];
+  error?: string;
+} {
+  const pairs: DevMetricsPair[] = [];
+
+  if (repos.length === contracts.length) {
+    for (let i = 0; i < repos.length; i++) {
+      pairs.push({ repo: repos[i], contract: contracts[i] });
+    }
+    return { pairs };
+  }
+
+  if (contracts.length === 1) {
+    for (const repo of repos) {
+      pairs.push({ repo, contract: contracts[0] });
+    }
+    return { pairs };
+  }
+
+  if (repos.length === 1) {
+    for (const contract of contracts) {
+      pairs.push({ repo: repos[0], contract });
+    }
+    return { pairs };
+  }
+
+  return {
+    pairs: [],
+    error: "Number of repositories and contracts must match, or one side must be singular",
+  };
+}
+
+export function parseAndValidateMaxPairs(maxPairsInput?: string): {
+  maxPairs: number;
+  error?: string;
+} {
+  if (!maxPairsInput) {
+    return { maxPairs: HARD_MAX_PAIRS };
+  }
+
+  const parsed = Number.parseInt(maxPairsInput, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return { maxPairs: HARD_MAX_PAIRS, error: "--max-pairs must be a positive integer" };
+  }
+
+  if (parsed > HARD_MAX_PAIRS) {
+    return { maxPairs: HARD_MAX_PAIRS, error: `--max-pairs cannot exceed ${HARD_MAX_PAIRS}` };
+  }
+
+  return { maxPairs: parsed };
+}

--- a/tests/devmetrics.integration.test.ts
+++ b/tests/devmetrics.integration.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/services/devmetrics/githubService.js", () => {
+  return {
+    GitHubService: class {
+      isAuthenticated() {
+        return true;
+      }
+      async getMetrics(owner: string, repo: string) {
+        return {
+          stars: 1,
+          lastCommitDate: "2024-01-01T00:00:00.000Z",
+          openIssuesCount: 2,
+          pullRequestsCount: 3,
+          contributorCount: 4,
+          repository: `${owner}/${repo}`,
+        };
+      }
+    },
+  };
+});
+
+vi.mock("../src/services/devmetrics/rootstockService.js", () => {
+  class MockRootstockService {
+    static async create() {
+      return new MockRootstockService();
+    }
+
+    getRedactedRpcUrl() {
+      return "https://public-node.rsk.co";
+    }
+
+    async getMetrics(contractAddress: string) {
+      return {
+        contractAddress,
+        deploymentBlock: 1,
+        totalTransactionCount: 1,
+        lastTransactionTimestamp: "2024-01-01T00:00:00.000Z",
+        gasUsagePatterns: { average: 1, min: 1, max: 1 },
+      };
+    }
+  }
+
+  return {
+    RootstockService: MockRootstockService,
+  };
+});
+
+vi.mock("../src/utils/devmetrics/rpcUrl.js", () => {
+  return {
+    validateRpcUrl: async () => new URL("https://public-node.rsk.co"),
+    redactRpcUrl: () => "https://public-node.rsk.co",
+  };
+});
+
+import { devMetricsCommand } from "../src/commands/devmetrics.js";
+
+describe("devmetrics orchestration", () => {
+  it("returns success for valid single pair", async () => {
+    const result = await devMetricsCommand({
+      repo: ["acme/repo"],
+      contract: ["0x1234567890abcdef1234567890abcdef12345678"],
+      network: "mainnet",
+      ci: true,
+      isExternal: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.reports.length).toBe(1);
+  });
+
+  it("fails fast for invalid input", async () => {
+    const result = await devMetricsCommand({
+      repo: [],
+      contract: ["0x1234567890abcdef1234567890abcdef12345678"],
+      ci: true,
+      isExternal: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("--repo");
+  });
+
+  it("fails fast for malformed github token", async () => {
+    const result = await devMetricsCommand({
+      repo: ["acme/repo"],
+      contract: ["0x1234567890abcdef1234567890abcdef12345678"],
+      githubToken: "bad token",
+      ci: true,
+      isExternal: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Invalid --github-token format");
+  });
+});

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { formatAsJSON } from "../src/formatters/devmetrics/json.js";
+import { formatAsMarkdown } from "../src/formatters/devmetrics/markdown.js";
+import { formatAsTable } from "../src/formatters/devmetrics/table.js";
+import { DevMetricsReport } from "../src/types/devmetrics.js";
+
+const sample: DevMetricsReport[] = [
+  {
+    repository: "acme/repo",
+    contractAddress: "0x1234567890abcdef1234567890abcdef12345678",
+    timestamp: new Date().toISOString(),
+    github: {
+      stars: 1,
+      lastCommitDate: new Date().toISOString(),
+      openIssuesCount: 2,
+      pullRequestsCount: 3,
+      contributorCount: 4,
+      repository: "acme/repo",
+    },
+    rootstock: {
+      contractAddress: "0x1234567890abcdef1234567890abcdef12345678",
+      deploymentBlock: 123,
+      totalTransactionCount: 9,
+      lastTransactionTimestamp: new Date().toISOString(),
+      gasUsagePatterns: { average: 1000, min: 900, max: 1200 },
+    },
+  },
+];
+
+describe("devmetrics formatters", () => {
+  it("formats JSON output", () => {
+    const output = formatAsJSON(sample);
+    expect(JSON.parse(output)[0].repository).toBe("acme/repo");
+  });
+
+  it("formats markdown output", () => {
+    const output = formatAsMarkdown(sample);
+    expect(output).toContain("# Developer Health Report: acme/repo");
+    expect(output).toContain("## GitHub Metrics");
+  });
+
+  it("formats table output", () => {
+    const output = formatAsTable(sample);
+    expect(output).toContain("Report for acme/repo");
+    expect(output).toContain("GitHub Metrics");
+    expect(output).toContain("Rootstock Metrics");
+  });
+});

--- a/tests/services.test.ts
+++ b/tests/services.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { GitHubService } from "../src/services/devmetrics/githubService.js";
+import { RootstockService } from "../src/services/devmetrics/rootstockService.js";
+
+describe("devmetrics services", () => {
+  it("fetches GitHub metrics from mocked octokit", async () => {
+    const svc = new GitHubService("token");
+    (svc as any).octokit = {
+      repos: {
+        get: async () => ({ data: { stargazers_count: 10, open_issues_count: 5 } }),
+        listCommits: async () => ({ data: [{ commit: { committer: { date: "2024-01-01T00:00:00.000Z" } } }] }),
+        listContributors: async () => ({ data: [{}, {}] }),
+      },
+      pulls: {
+        list: async () => ({ data: [{}] }),
+      },
+      search: {
+        issuesAndPullRequests: async () => ({ data: { total_count: 3 } }),
+      },
+    };
+
+    const res = await svc.getMetrics("acme", "repo");
+    expect(res.repository).toBe("acme/repo");
+    expect(res.stars).toBe(10);
+    expect(res.pullRequestsCount).toBe(3);
+  });
+
+  it("fetches Rootstock metrics from mocked client", async () => {
+    const svc = await RootstockService.create("https://public-node.rsk.co", "mainnet");
+    (svc as any).client = {
+      getBlockNumber: async () => 1000n,
+      getBytecode: async () => "0x1234",
+      getBlock: async () => ({
+        timestamp: 1700000000n,
+        transactions: [{ hash: "0xabc", to: "0x1234567890abcdef1234567890abcdef12345678" }],
+      }),
+      getTransactionReceipt: async () => ({ gasUsed: 21000n }),
+    };
+
+    const res = await svc.getMetrics("0x1234567890abcdef1234567890abcdef12345678");
+    expect(res.contractAddress.toLowerCase()).toBe("0x1234567890abcdef1234567890abcdef12345678");
+    expect(res.gasUsagePatterns.average).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPairs,
+  parseAndValidateMaxPairs,
+  parseRepoIdentifier,
+  validateContractAddress,
+  validateOutputFormat,
+  validateRepo,
+} from "../src/utils/devmetrics/validation.js";
+
+describe("devmetrics validation", () => {
+  it("validates repo format", () => {
+    expect(validateRepo("owner/repo").valid).toBe(true);
+    expect(validateRepo("badrepo").valid).toBe(false);
+  });
+
+  it("validates contract address format", () => {
+    expect(validateContractAddress("0x1234567890abcdef1234567890abcdef12345678").valid).toBe(true);
+    expect(validateContractAddress("0xabc").valid).toBe(false);
+  });
+
+  it("validates output format", () => {
+    expect(validateOutputFormat("table")).toBe(true);
+    expect(validateOutputFormat("json")).toBe(true);
+    expect(validateOutputFormat("markdown")).toBe(true);
+    expect(validateOutputFormat("xml")).toBe(false);
+  });
+
+  it("parses repo defensively", () => {
+    expect(parseRepoIdentifier("foo/bar")).toEqual({ owner: "foo", repo: "bar" });
+    expect(parseRepoIdentifier("foo")).toHaveProperty("error");
+  });
+
+  it("builds repo/contract pairs", () => {
+    expect(buildPairs(["a/b"], ["0x1", "0x2"]).pairs).toHaveLength(2);
+    expect(buildPairs(["a/b", "c/d"], ["0x1"]).pairs).toHaveLength(2);
+    expect(buildPairs(["a/b", "c/d"], ["0x1", "0x2"]).pairs).toHaveLength(2);
+    expect(buildPairs(["a/b", "c/d"], ["0x1", "0x2", "0x3"]).error).toBeDefined();
+  });
+
+  it("validates max-pairs bounds", () => {
+    expect(parseAndValidateMaxPairs("10").maxPairs).toBe(10);
+    expect(parseAndValidateMaxPairs("0").error).toBeDefined();
+    expect(parseAndValidateMaxPairs("26").error).toBeDefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    clearMocks: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Added `devmetrics` to `rsk-cli` with isolated command/service/formatter modules and no core command regressions.
- Fixed SSRF risk for `--rpc-url` and env RPC URLs via strict URL validation (scheme + DNS/IP private/local/metadata blocking, with explicit `--allow-private-rpc` opt-in).
- Fixed Rootstock gas metrics correctness by using transaction receipts (`gasUsed`) instead of transaction response fallbacks.
- Added RPC URL redaction in output to prevent credential leakage in logs.
- Added token hardening for `--github-token` (format validation + exposure warning; recommend `GITHUB_TOKEN` env var).
- Enforced `MAX_PAIRS` guard to prevent combinatorial fan-out/resource exhaustion.
- Replaced recursive GitHub auth fallback with deterministic single-pass fallback logic.
- Added deterministic CI behavior: single JSON envelope output with exit codes (`0` success, `2` partial, `1` failure).
- Fixed README merge conflicts and added concise `devmetrics` usage + security notes.
- Added focused test coverage for validation, formatters, services, and command orchestration.

## Security/Quality Impact
- Closes high-risk SSRF vector and medium-risk secret/logging exposure paths in `devmetrics`.
- Corrects inaccurate gas reporting behavior.
- Improves CI reliability and machine-readability for downstream automation.